### PR TITLE
Fix histograms to be cumulative

### DIFF
--- a/src/histogram.js
+++ b/src/histogram.js
@@ -4,7 +4,7 @@ import { resetAll } from './mixins';
 import Collector from './collector';
 
 function findMinBucketIndex(ary, num) {
-  if (num > ary[ary.lenght - 1]) { return null; }
+  if (num > ary[ary.length - 1]) { return null; }
 
   for (let i = 0; i < ary.length; i += 1) {
     if (num <= ary[i]) {

--- a/src/histogram.js
+++ b/src/histogram.js
@@ -3,27 +3,12 @@ import { reduce, sum } from 'lodash';
 import { resetAll } from './mixins';
 import Collector from './collector';
 
-function findBucket(ary, num) {
-  const max = Math.max.apply(null, ary);
-  const min = Math.min.apply(null, ary);
-  // Lower than the smallest bucket
-  if (num < min) { return null; }
-  // Equals the smallest bucket
-  if (num === min) { return min; }
-  // Bigger/equal to the the largest bucket.
-  if (num >= max) { return max; }
+function findMinBucketIndex(ary, num) {
+  if (num > ary[ary.lenght - 1]) { return null; }
 
-  // This works because histogram bucket arrays are sorted smallest to largest.
   for (let i = 0; i < ary.length; i += 1) {
-    const bound = ary[i];
-    const next = ary[i + 1];
-    // End of the array;
-    if (!next) { return max; }
-
-    if (bound === num) {
-      return bound;
-    } else if (bound < num && num < next) {
-      return bound;
+    if (num <= ary[i]) {
+      return i;
     }
   }
 }
@@ -33,7 +18,7 @@ function getInitialValue(buckets) {
   const entries = reduce(buckets, (result, b) => {
     result[b.toString()] = 0;
     return result;
-  }, {});
+  }, { '+Inf': 0 });
 
   return {
     sum: 0,
@@ -59,11 +44,17 @@ export default class Histogram extends Collector {
       //Create a metric for the labels.
       metric = this.set(getInitialValue(this.buckets), labels).get(labels);
     }
+
     metric.value.raw.push(value);
-    const bucket = findBucket(this.buckets, value);
-    if (bucket) {
-      const val = metric.value.entries[bucket.toString()];
-      metric.value.entries[bucket.toString()] = val + 1;
+    metric.value.entries['+Inf']++;
+
+    const minBucketIndex = findMinBucketIndex(this.buckets, value);
+
+    if (minBucketIndex !== null) {
+      for (let i = minBucketIndex; i < this.buckets.length; i++) {
+        const val = metric.value.entries[this.buckets[i].toString()];
+        metric.value.entries[this.buckets[i].toString()] = val + 1;
+      }
     }
 
     metric.value.sum = sum(metric.value.raw);

--- a/test/histogram-test.js
+++ b/test/histogram-test.js
@@ -15,16 +15,18 @@ describe('Histogram', function () {
     histogram.observe(380);
     histogram.observe(400);
     histogram.observe(199);
+    histogram.observe(1200);
     const result = histogram.collect();
     result.length.should.equal(1);
     result[0].value.should.containEql({
-      sum: 979,
-      count: 3,
+      sum: 2179,
+      count: 4,
       entries: {
         '200': 1,
-        '400': 1,
-        '750': 0,
-        '1000': 0
+        '400': 3,
+        '750': 3,
+        '1000': 3,
+        '+Inf': 4
       }
     });
   });
@@ -43,7 +45,8 @@ describe('Histogram', function () {
           '200': 0,
           '400': 0,
           '750': 0,
-          '1000': 0
+          '1000': 0,
+          '+Inf': 0
         }
       }
     }]);

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -45,14 +45,21 @@ describe('promjs', function () {
     histogram.observe(300);
     desired.push('response_time_count 2\n');
     desired.push('response_time_sum 599\n');
-    desired.push('response_time_bucket{le="200"} 1\n');
-    desired.push('response_time_bucket{le="300"} 1\n');
+    desired.push('response_time_bucket{le="200"} 0\n');
+    desired.push('response_time_bucket{le="300"} 2\n');
+    desired.push('response_time_bucket{le="400"} 2\n');
+    desired.push('response_time_bucket{le="500"} 2\n');
+    desired.push('response_time_bucket{le="+Inf"} 2\n');
 
     histogram.observe(401, { path: '/api/users', status: 200 });
     histogram.observe(253, { path: '/api/users', status: 200 });
     histogram.observe(499, { path: '/api/users', status: 200 });
-    desired.push('response_time_bucket{le="400",path="/api/users",status="200"} 2\n');
-    desired.push('response_time_bucket{le="200",path="/api/users",status="200"} 1\n');
+    histogram.observe(700, { path: '/api/users', status: 200 });
+    desired.push('response_time_bucket{le="200",path="/api/users",status="200"} 0\n');
+    desired.push('response_time_bucket{le="300",path="/api/users",status="200"} 1\n');
+    desired.push('response_time_bucket{le="400",path="/api/users",status="200"} 1\n');
+    desired.push('response_time_bucket{le="500",path="/api/users",status="200"} 3\n');
+    desired.push('response_time_bucket{le="+Inf",path="/api/users",status="200"} 4\n');
 
     actual = registry.metrics();
   });


### PR DESCRIPTION
## Summary

Prometheus Histograms should be cumulative. See [Histograms and summaries](https://prometheus.io/docs/practices/histograms/):

> [...] The reason is that the histogram buckets are cumulative. The `le="0.3"` bucket is also contained in the `le="1.2"` bucket; dividing it by 2 corrects for that. [...]

This PR changes the Histograms in PromJS to count in cumulative matter.

## Implementation details

- Changed `findBucket` to `findMinBucketIndex`. Because the buckets are sorted, once you find the lowest bucket that fits a number, you increment the counters of all buckets after it.
- Added explicit definition of the '+Inf' bucket.
- Adjusted unit tests & integration test.

## Future improvements
- `findMinBucketIndex` could be implemented with a binary search.