### PR TITLE
Change lodash imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha",
+    "test-watch": "mocha --watch",
     "lint": "eslint src test",
     "build": "babel src --out-dir lib && webpack-cli -p && cp package.json README.md index.d.ts ./lib",
     "release": "yarn lint && yarn test && yarn version && yarn build && yarn push",

--- a/src/collector.js
+++ b/src/collector.js
@@ -1,6 +1,6 @@
-import filter from "lodash/filter";
-import matches from "lodash/matches";
-import { findExistingMetric } from "./utils";
+import filter from 'lodash/filter';
+import matches from 'lodash/matches';
+import { findExistingMetric } from './utils';
 
 export default class Collector {
   constructor() {

--- a/src/collector.js
+++ b/src/collector.js
@@ -1,5 +1,6 @@
-import { filter, matches } from 'lodash';
-import { findExistingMetric } from './utils';
+import filter from "lodash/filter";
+import matches from "lodash/matches";
+import { findExistingMetric } from "./utils";
 
 export default class Collector {
   constructor() {

--- a/src/histogram.js
+++ b/src/histogram.js
@@ -1,8 +1,8 @@
-import reduce from "lodash/reduce";
-import sum from "lodash/sum";
+import reduce from 'lodash/reduce';
+import sum from 'lodash/sum';
 
-import { resetAll } from "./mixins";
-import Collector from "./collector";
+import { resetAll } from './mixins';
+import Collector from './collector';
 
 function findMinBucketIndex(ary, num) {
   if (num > ary[ary.length - 1]) { return null; }

--- a/src/histogram.js
+++ b/src/histogram.js
@@ -1,7 +1,8 @@
-import { reduce, sum } from 'lodash';
+import reduce from "lodash/reduce";
+import sum from "lodash/sum";
 
-import { resetAll } from './mixins';
-import Collector from './collector';
+import { resetAll } from "./mixins";
+import Collector from "./collector";
 
 function findMinBucketIndex(ary, num) {
   if (num > ary[ary.length - 1]) { return null; }

--- a/src/mixins.js
+++ b/src/mixins.js
@@ -1,4 +1,5 @@
-import { each, omit } from 'lodash';
+import each from "lodash/each";
+import omit from "lodash/omit";
 
 export function add(amount, labels) {
   if (typeof amount !== 'number') {

--- a/src/mixins.js
+++ b/src/mixins.js
@@ -1,5 +1,5 @@
-import each from "lodash/each";
-import omit from "lodash/omit";
+import each from 'lodash/each';
+import omit from 'lodash/omit';
 
 export function add(amount, labels) {
   if (typeof amount !== 'number') {

--- a/src/registry.js
+++ b/src/registry.js
@@ -1,4 +1,9 @@
-import { zipObject, has, each, reduce, find, valuesIn } from 'lodash';
+import zipObject from "lodash/zipObject";
+import has from "lodash/has";
+import each from "lodash/each";
+import reduce from "lodash/reduce";
+import find from "lodash/find";
+import valuesIn from "lodash/valuesIn";
 
 import { formatHistogramOrSummary, formatCounterOrGauge } from './utils';
 import Counter from './counter';

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,13 +1,13 @@
-import isEqual from "lodash/isEqual";
-import omit from "lodash/omit";
-import reduce from "lodash/reduce";
-import find from "lodash/find";
+import isEqual from 'lodash/isEqual';
+import omit from 'lodash/omit';
+import reduce from 'lodash/reduce';
+import find from 'lodash/find';
 
 const getPairs = data => Object.keys(data).map(key => `${key}="${data[key]}"`);
 
 function getLabelPairs(metric) {
-  const pairs = getPairs(omit(metric, "value"));
-  return pairs.length === 0 ? "" : `${pairs.join(",")}`;
+  const pairs = getPairs(omit(metric, 'value'));
+  return pairs.length === 0 ? '' : `${pairs.join(',')}`;
 }
 
 export function formatHistogramOrSummary(name, metric, bucketLabel = 'le') {
@@ -46,9 +46,9 @@ export function formatCounterOrGauge(name, metric) {
   const value = ` ${metric.value.toString()}`;
   // If there are no keys on `metric`, it doesn't have a label;
   // return the count as a string.
-  if (keys(metric).length === 1 && typeof metric.value === 'number') {
+  if (Object.keys(metric).length === 1 && typeof metric.value === 'number') {
     return `${name}${value}\n`;
   }
-  const pair = getPairs(omit(metric, "value"));
-  return `${name}{${pair.join(",")}}${value}\n`;
+  const pair = getPairs(omit(metric, 'value'));
+  return `${name}{${pair.join(',')}}${value}\n`;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,16 +1,13 @@
-import {
-  isEqual,
-  omit,
-  keys,
-  map,
-  find,
-  reduce
-} from 'lodash';
+import isEqual from "lodash/isEqual";
+import omit from "lodash/omit";
+import reduce from "lodash/reduce";
+import find from "lodash/find";
 
+const getPairs = data => Object.keys(data).map(key => `${key}="${data[key]}"`);
 
 function getLabelPairs(metric) {
-  const pairs = map(omit(metric, 'value'), (v, k) => `${k}="${v}"`);
-  return pairs.length === 0 ? '' : `${pairs.join(',')}`;
+  const pairs = getPairs(omit(metric, "value"));
+  return pairs.length === 0 ? "" : `${pairs.join(",")}`;
 }
 
 export function formatHistogramOrSummary(name, metric, bucketLabel = 'le') {
@@ -52,6 +49,6 @@ export function formatCounterOrGauge(name, metric) {
   if (keys(metric).length === 1 && typeof metric.value === 'number') {
     return `${name}${value}\n`;
   }
-  const pair = map(omit(metric, 'value'), (v, k) => `${k}="${v}"`);
-  return `${name}{${pair.join(',')}}${value}\n`;
+  const pair = getPairs(omit(metric, "value"));
+  return `${name}{${pair.join(",")}}${value}\n`;
 }


### PR DESCRIPTION
Hi there,

We've started using your package (which is great, by the way, thank you!) recently, and I noticed that it started bloating the JS file that it gets included into. Digging into it a bit further, I saw that this package was importing lodash components as `import {foo, bar} from 'lodash'`, which imports the entire lodash package. I've changed the imports to be 
```
import foo from 'lodash/foo';
import bar from 'lodash/bar';
```
which imports only the specific modules required. Doing this should reduce the file size footprint of this package :).

- I also started work on replacing some of the lodash functions with native JS implementations, such as in the `utils.js` file. In this particular instance I replaced the `lodash.keys` method with `Object.keys` and `lodash.map` with the `Array.map` function. There are a few other instances this could be done, such as in the usage of `filter`, `reduce`, and a few other methods, but I thought I'd get this merged in first and return to these later.

Thanks, and let me know if I missed anything or you have any questions!