### PR TITLE
Transfer ownership to @weaveworks and update the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ A Prometheus metrics registry implemented in TypeScript
 ### Installation
 Install via `npm`:
 
-`$ npm install --save promjs`
+`$ npm install --save @weaveworks/promjs`
 
 or via `yarn`:
 
-`$ yarn add promjs`
+`$ yarn add @weaveworks/promjs`
 
 
 ### Usage

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "promjs",
+  "name": "@weaveworks/promjs",
   "version": "0.4.0",
   "description": "",
   "main": "lib/index.js",
@@ -14,6 +14,9 @@
     "push": "cd lib && npm login && npm publish && git push --set-upstream origin master --follow-tags"
   },
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "@babel/cli": "^7.2.3",
     "@babel/core": "^7.3.3",


### PR DESCRIPTION
@dimitropoulos @guyfedwards 
Transfers ownership to @weavworks and updates the docs!

Once this is merged, we can discuss the right way to deprecate the old packages.

I'm thinking we don't need to deprecate if we just bump the version on the new @weaveworks version, but it might be nice to give people a message letting them know the old one is no longer supported.