### PR TITLE
Update docs to mention registry.reset()

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ console.log(registry.metrics());
 ```
 
 #### registry.clear() => self
+Removes all metrics from internal `data` storage. Returns itself to allow for chaining.
+
+#### registry.reset() => self
 Resets all existing metrics to 0. This can be used to reset metrics after reporting to a prometheus aggregator. Returns itself to allow for chaining.
 
 


### PR DESCRIPTION
Resolves #29.

Not sure about the documentation for `clear`, but it seems to me that the docs for `clear` more accurately reflected `reset`, so I reused those and changed `clear`'s to reflect what it seems to do. Could maybe use some editing to demonstrate when it would be used?