### PR TITLE
Move from lodash to es6

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,13 +22,11 @@
     "@babel/preset-env": "^7.3.1",
     "@babel/preset-typescript": "^7.3.3",
     "@types/chai": "^4.1.7",
-    "@types/lodash": "^4.14.121",
     "@types/mocha": "^5.2.6",
     "@types/node": "^11.9.3",
     "@typescript-eslint/eslint-plugin": "^1.4.0",
     "@typescript-eslint/parser": "^1.4.0",
     "babel-loader": "^8.0.5",
-    "babel-plugin-lodash": "^3.3.4",
     "chai": "^4.2.0",
     "eslint": "^5.16.0",
     "eslint-config-airbnb-typescript": "^1.1.0",
@@ -36,13 +34,11 @@
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-react": "^7.12.4",
     "mocha": "^4.1.0",
+    "terser-webpack-plugin": "^4.2.3",
     "ts-node": "^8.0.2",
     "typescript": "^3.3.3",
-    "terser-webpack-plugin": "^4.2.3",
     "webpack": "^4.42.1",
     "webpack-cli": "^3.3.11"
   },
-  "dependencies": {
-    "lodash": "^4.17.12"
-  }
+  "dependencies": {}
 }

--- a/src/collector.ts
+++ b/src/collector.ts
@@ -1,4 +1,3 @@
-import { filter, matches, each } from 'lodash';
 import { Labels, Metric, MetricValue } from './types';
 import { findExistingMetric } from './utils';
 
@@ -28,13 +27,28 @@ export abstract class Collector<T extends MetricValue> {
   }
 
   collect(labels?: Labels): Metric<T>[] {
-    return filter(this.data, item => matches(labels)(item.labels));
+    if (!labels) {
+      return this.data;
+    }
+    return this.data.filter((item) => {
+      if (!item.labels) {
+        return false;
+      }
+      const entries = Object.entries(labels);
+      for (let i = 0; i < entries.length; i += 1) {
+        const [label, value] = entries[i];
+        if (item.labels[label] !== value) {
+          return false;
+        }
+      }
+      return true;
+    });
   }
 
   resetAll(): this {
-    each(this.data, (d) => {
-      this.reset(d.labels);
-    });
+    for (let i = 0; i < this.data.length; i += 1) {
+      this.reset(this.data[i].labels);
+    }
 
     return this;
   }

--- a/src/histogram.ts
+++ b/src/histogram.ts
@@ -1,5 +1,3 @@
-import { reduce, sum } from 'lodash';
-
 import { Collector } from './collector';
 import { HistogramValue, HistogramValueEntries, Labels } from './types';
 
@@ -17,7 +15,7 @@ function findMinBucketIndex(ary: number[], num: number): number | undefined {
 
 function getInitialValue(buckets: number[]): HistogramValue {
   // Make the skeleton to which values will be saved.
-  const entries = reduce(buckets, (result, b) => {
+  const entries = buckets.reduce((result, b) => {
     result[b.toString()] = 0;
     return result;
   }, { '+Inf': 0 } as HistogramValueEntries);
@@ -60,7 +58,7 @@ export class Histogram extends Collector<HistogramValue> {
       }
     }
 
-    metric.value.sum = sum(metric.value.raw);
+    metric.value.sum = metric.value.raw.reduce((sum, v) => sum + v, 0);
     metric.value.count += 1;
 
     return this;

--- a/test/integration-test.ts
+++ b/test/integration-test.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import { each, includes, last } from 'lodash';
 import prom from '../src';
 import { Registry } from '../src/registry';
 
@@ -70,11 +69,12 @@ describe('promjs', () => {
   });
 
   it('reports metrics', () => {
-    each(desired, (d) => {
-      if (!includes(actual, d)) {
+    for (let i = 0; i < desired.length; i += 1) {
+      const d = desired[i];
+      if (!actual.includes(d)) {
         errors.push(`Actual: ${actual}\nExpected: ${d}`);
       }
-    });
+    }
 
     expect(errors).deep.equals([], errors.join('\n'));
   });
@@ -84,10 +84,11 @@ describe('promjs', () => {
 
     // Check that the end of each metric string is a 0
     expect(cleared.length).greaterThan(5);
-    each(cleared, (m) => {
-      if (m && !includes(m, 'TYPE') && !includes(m, 'HELP')) {
-        expect(last(m)).equals('0');
+    for (let i = 0; i < cleared.length; i += 1) {
+      const m = cleared[i];
+      if (m && !m.includes('TYPE') && !m.includes('HELP')) {
+        expect(m.slice(-1)).equals('0');
       }
-    });
+    }
   });
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,7 +33,7 @@ module.exports = (env, options) => {
         loader: 'babel-loader',
         exclude: /(node_modules)/,
         query: {
-          plugins: ['lodash', '@babel/proposal-class-properties', '@babel/proposal-object-rest-spread'],
+          plugins: ['@babel/proposal-class-properties', '@babel/proposal-object-rest-spread'],
           presets: ['@babel/env']
         }
       }]

--- a/yarn.lock
+++ b/yarn.lock
@@ -139,7 +139,7 @@
   dependencies:
     "@babel/types" "^7.0.0"
 
-"@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.0.0-beta.49":
+"@babel/helper-module-imports@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz#96081b7111e486da4d2cd971ad1a4fe216cc2e3d"
   integrity sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==
@@ -642,7 +642,7 @@
     globals "^11.1.0"
     lodash "^4.17.10"
 
-"@babel/types@^7.0.0", "@babel/types@^7.0.0-beta.49", "@babel/types@^7.2.0", "@babel/types@^7.2.2", "@babel/types@^7.3.0", "@babel/types@^7.3.3":
+"@babel/types@^7.0.0", "@babel/types@^7.2.0", "@babel/types@^7.2.2", "@babel/types@^7.3.0", "@babel/types@^7.3.3":
   version "7.3.3"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.3.3.tgz#6c44d1cdac2a7625b624216657d5bc6c107ab436"
   integrity sha512-2tACZ80Wg09UnPg5uGAOUvvInaqLk3l/IAhQzlxLQOIXacr6bMsra5SH6AWw/hIDRCSbCdHP2KzSOD+cT7TzMQ==
@@ -668,11 +668,6 @@
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
-
-"@types/lodash@^4.14.121":
-  version "4.14.121"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.121.tgz#9327e20d49b95fc2bf983fc2f045b2c6effc80b9"
-  integrity sha512-ORj7IBWj13iYufXt/VXrCNMbUuCTJfhzme5kx9U/UtcIPdJYuvPDUAlHlbNhz/8lKCLy9XGIZnGrqXOtQbPGoQ==
 
 "@types/mocha@^5.2.6":
   version "5.2.6"
@@ -1072,17 +1067,6 @@ babel-loader@^8.0.5:
     loader-utils "^1.0.2"
     mkdirp "^0.5.1"
     util.promisify "^1.0.0"
-
-babel-plugin-lodash@^3.3.4:
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/babel-plugin-lodash/-/babel-plugin-lodash-3.3.4.tgz#4f6844358a1340baed182adbeffa8df9967bc196"
-  integrity sha512-yDZLjK7TCkWl1gpBeBGmuaDIFhZKmkoL+Cu2MUUjv5VxUZx/z7tBGBCBcQs5RI1Bkz5LLmNdjx7paOyQtMovyg==
-  dependencies:
-    "@babel/helper-module-imports" "^7.0.0-beta.49"
-    "@babel/types" "^7.0.0-beta.49"
-    glob "^7.1.1"
-    lodash "^4.17.10"
-    require-package-name "^2.0.1"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -2398,7 +2382,7 @@ glob@7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
+glob@^7.0.0, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -4138,11 +4122,6 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
-
-require-package-name@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/require-package-name/-/require-package-name-2.0.1.tgz#c11e97276b65b8e2923f75dabf5fb2ef0c3841b9"
-  integrity sha1-wR6XJ2tluOKSP3Xav1+y7ww4Qbk=
 
 requireindex@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
lodash accounts for an important part of this build, and its methods are
natively available in es6.
This commit replaces them.

Addresses weaveworks#51.

Re-open #53 