### PR TITLE
Fix path to main

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promjs",
-  "version": "0.5.0",
+  "version": "0.4.2",
   "description": "",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -11,7 +11,7 @@
     "lint": "eslint --ext .ts src test",
     "test": "mocha --recursive \"test/**/*-test.ts\"",
     "release": "yarn lint && yarn test && yarn version && yarn build && yarn push",
-    "push": "cd lib && npm login && npm publish && git push --set-upstream origin master --follow-tags"
+    "push": "npm login && npm publish && git push --set-upstream origin master --follow-tags"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promjs",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",


### PR DESCRIPTION
Remove `cd lib` from push script, which caused index.js to end up in the root of the package.

This caused problems for us when trying to switch from webpack to vite. Apparently webpack manages to find `index.js` even if the path in package.json does not match the file location, but vite does not. We have a dependency to `@cabify/prom-react` which has a dependency to promjs.

This has been tested by publishing to npm with a different package name and overriding in our project.

The fix was suggested by @smithamax

Fixes weaveworks/promjs#23